### PR TITLE
Add missing WakaTime settings requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 1. Create a new public GitHub Gist (https://gist.github.com/)
 1. Create a token with the `gist` scope and copy it. (https://github.com/settings/tokens/new)
 1. Create a WakaTime account (https://wakatime.com/signup)
+1. In your WakaTime profile settings (https://wakatime.com/settings/profile) ensure `Display coding activity publicly` and `Display languages, editors, operating systems publicly` are checked.
 1. In your account settings, copy the existing WakaTime API Key (https://wakatime.com/settings/api-key)
 
 ### Project setup


### PR DESCRIPTION
I was trying to set waka-box up, but it was unable to get the data at all. In fact, it corrupted the gist completely after the second time it ran.

Turns out you need your activity and languages public, even though we're accessing it through the private API key.

![image](https://user-images.githubusercontent.com/21304428/77748180-39d8df00-7020-11ea-8d12-7ca5370f5db5.png)

Basically the same requirements to be on the WakaTime Leaderboard.

----------

_(optional)_
Maybe there is a way to catch this in our script, since the pipeline succeeds without realizing anything is wrong. Even something as simple as a check for setting the gist's content to an empty or whitespace string would help.

Though I'm not too sure, I just wanted to get this to work. 😅 
Hopefully this will help someone.