### PR TITLE
Issue with Github Actions not running automaticaly

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,7 +1,7 @@
 name: Update gist with WakaTime stats
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 * * * *"
   watch:
     types: [started]
 jobs:

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,14 +2,16 @@ name: Update gist with WakaTime stats
 on:
   schedule:
     - cron: "0 0 * * *"
+  watch:
+    types: [started]
 jobs:
   update-gist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Update gist
-        uses: matchai/waka-box@master
+        uses: ./
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIST_ID: 968220c97e8da1d047a9a480fa432e54
+          GIST_ID: 7e6161eb6011491d361d0fdfe6002b3d
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Update gist
-        uses: ./
+        uses: vaishak47/waka-box@master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GIST_ID: 7e6161eb6011491d361d0fdfe6002b3d


### PR DESCRIPTION
I faced the same issue with the Github actions not running alternatively.
Even tried the temporary workaround mentioned [here](https://github.community/t5/GitHub-Actions/Forked-repo-doesn-t-trigger-action/m-p/32575#M1189).

After the following changes it seems to be running fine.