### PR TITLE
Add timezone in environment variable

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,6 +11,6 @@ jobs:
         uses: matchai/waka-box@master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIST_ID: 8d3fa83f973d0e2fd9d193c150ca35db
+          GIST_ID: 968220c97e8da1d047a9a480fa432e54
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
-          TIMEZONE: Asia/Seoul
+          TIMEZONE: America/New_York

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -11,5 +11,6 @@ jobs:
         uses: matchai/waka-box@master
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          GIST_ID: 968220c97e8da1d047a9a480fa432e54
+          GIST_ID: 8d3fa83f973d0e2fd9d193c150ca35db
           WAKATIME_API_KEY: ${{ secrets.WAKATIME_API_KEY }}
+          TIMEZONE: Asia/Seoul

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@
 1. Edit the [environment variable](https://github.com/matchai/waka-box/blob/master/.github/workflows/schedule.yml#L13-L15) in `.github/workflows/schedule.yml`:
 
    - **GIST_ID:** The ID portion from your gist url: `https://gist.github.com/matchai/`**`6d5f84419863089a167387da62dd7081`**.
+   - **TIMEZONE:** The timezone of your location:
+   `Ameria/New_York` for Montreal in Canada, `Asia/Seoul` for Korea, etc.
 
 1. Go to the repo **Settings > Secrets**
 1. Add the following environment variables:


### PR DESCRIPTION
Add `TIMEZONE` in environment variable and update README.md for `matchai/waka-box`'s global users.