### PR TITLE
add workflow_dispatch to manually trigger workflow

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,6 +2,8 @@ name: Update gist with WakaTime stats
 on:
   schedule:
     - cron: "0 0 * * *"
+  # Manual triggers with workflow_dispatch
+  workflow_dispatch:
 jobs:
   update-gist:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Reference link** : [create workflows that are manually triggered with the new workflow_dispatch event.](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)


+ We can now create workflows that are manually triggered with the new `workflow_dispatch` event.
+ We will then see a ‘Run workflow’ button on the Actions tab, enabling you to easily trigger a run.
+ We can choose which branch the workflow is run on.

![image](https://user-images.githubusercontent.com/35565811/156478402-d2b7ee94-99da-4d02-ae05-6d68916a4269.png)